### PR TITLE
feat(docker): remove unecessary println && add publish workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -18,8 +18,8 @@ jobs:
         toolchain: [stable]
         arch:
           - {os: "ubuntu-latest", target: "x86_64-unknown-linux-gnu", cross: false}
-          - {os: "ubuntu-latest", target: "armv7-unknown-linux-gnueabihf", cross: true}
-          - {os: "ubuntu-latest", target: "aarch64-unknown-linux-gnu", cross: true}
+#          - {os: "ubuntu-latest", target: "armv7-unknown-linux-gnueabihf", cross: true}
+#          - {os: "ubuntu-latest", target: "aarch64-unknown-linux-gnu", cross: true}
 
     steps:
       - name: "Checkout repo 👉"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: "Release docker image"
+run-name: "Release docker image: ${{ github.event.release.name }} ⛑️"
+
+on:
+  push:
+#  release:
+#    types: [published]
+
+jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v2
+#        if: github.event_name != 'pull_request'
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        id: docker_build
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,8 @@ name: "Release docker image"
 run-name: "Release docker image: ${{ github.event.release.name }} ⛑️"
 
 on:
-  push:
-#  release:
-#    types: [published]
+  release:
+    types: [published]
 
 jobs:
   docker:
@@ -37,12 +36,11 @@ jobs:
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
 
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v2
-#        if: github.event_name != 'pull_request'
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v4
@@ -52,6 +50,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 FROM --platform=$BUILDPLATFORM rust:bookworm as vendor
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
-RUN echo "Running on: $BUILDPLATFORM / Building for $TARGETPLATFORM"
 WORKDIR /app
-
 COPY ./Cargo.toml .
-#COPY ./Cargo.lock .
 COPY ./src src
 RUN mkdir .cargo && cargo vendor > .cargo/config.toml
 
@@ -15,7 +12,6 @@ WORKDIR /app
 COPY --from=vendor /app/.cargo .cargo
 COPY --from=vendor /app/vendor vendor
 COPY ./Cargo.toml .
-#COPY ./Cargo.lock .
 COPY ./src src
 RUN cargo build --release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM --platform=$BUILDPLATFORM rust:bookworm as vendor
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+RUN echo "Running on: $BUILDPLATFORM / Building for $TARGETPLATFORM"
+WORKDIR /app
+
+COPY ./Cargo.toml .
+#COPY ./Cargo.lock .
+COPY ./src src
+RUN mkdir .cargo && cargo vendor > .cargo/config.toml
+
+FROM rust:bookworm as builder
+WORKDIR /app
+
+COPY --from=vendor /app/.cargo .cargo
+COPY --from=vendor /app/vendor vendor
+COPY ./Cargo.toml .
+#COPY ./Cargo.lock .
+COPY ./src src
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+WORKDIR /app
+ENV RUST_BACKTRACE=full
+COPY --from=builder /app/target/release/livebox-exporter-rs livebox-exporter-rs
+
+EXPOSE 9100
+ENTRYPOINT ["/app/livebox-exporter-rs"]

--- a/src/livebox_client_rs/client.rs
+++ b/src/livebox_client_rs/client.rs
@@ -137,7 +137,6 @@ impl Client {
             .authenticated_post_request("DeviceInfo", "get", serde_json::json!({}))
             .await;
         let json: Value = serde_json::from_slice(&body_bytes).expect("Could not parse JSON.");
-        println!("Body was: '{}'.", std::str::from_utf8(&body_bytes).unwrap());
         assert!(
             parts.status.is_success(),
             "Router answered with something else than a success code."
@@ -153,7 +152,6 @@ impl Client {
             .authenticated_post_request("NMC", "getWANStatus", serde_json::json!({}))
             .await;
         let json: Value = serde_json::from_slice(&body_bytes).expect("Could not parse JSON.");
-        println!("Body was: '{}'.", std::str::from_utf8(&body_bytes).unwrap());
         assert!(
             parts.status.is_success(),
             "Router answered with something else than a success code."
@@ -185,7 +183,6 @@ impl Client {
             .authenticated_post_request("HomeLan", "getResults", post_data)
             .await;
         let json: Value = serde_json::from_slice(&body_bytes).expect("Could not parse JSON.");
-        println!("Body was: '{}'.", std::str::from_utf8(&body_bytes).unwrap());
         let mut metrics: Vec<Metrics> = Vec::new();
         if let Some(status) = json["status"].as_object() {
             for (key, value) in status.iter() {


### PR DESCRIPTION
#8 

Purpose of this PR is to remove some unecessary println forgotten in client.rs and add the publish workflow for dockerhub.

Note that this workflow for testing/debugging purpose is set to run on all push without publishing anything to dockerhub.

It will then be switch back to only listen to `github.event.release` on the main branch