### PR TITLE
fix(args): add gateway param & update tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "livebox-exporter-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "livebox-exporter-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Available:
 - **Should work** on livebox 4 and upper 🤷🏻‍
 - **Extracts metrics:** general status, wan configuration, devices status, bandwidth
 - **Exposes metrics:** in Prometheus format, compatible with Grafana
+- **Docker image:** [tchapacan/livebox-exporter-rs:latest](https://hub.docker.com/r/tchapacan/livebox-exporter-rs)
 
 Future:
 
-- *Docker image soon available...*
 - *Grafana dashboard template soon available...*
 - *More metrics...*
 
@@ -51,7 +51,26 @@ Future:
 
 ## Usage
 
-To use **livebox-exporter-rs**, follow these steps:
+### Docker
+
+1. **Pull latest docker image:** to your local machine.
+
+   ```bash
+   docker pull tchapacan/livebox-exporter-rs:latest
+   ```
+
+2. **Run the Exporter:** run the docker images, using the options.
+
+    ```bash
+    docker run -d --name livebox-exporter-rs -h livebox-exporter-rs -p <exporter_port>:<exporter_port> tchapacan/livebox-exporter-rs:latest --password <livebox_password> --port <exporter_port>
+    ```
+
+3. **Access Metrics:** Once the exporter is running, access the exposed metrics at:
+
+   `http://localhost:<exporter_port>/metrics`
+
+
+### Sources
 
 1. **Clone the Repository:** to your local machine.
 
@@ -86,6 +105,7 @@ Supported command-line options (hope `-P` vs `-p` not to confusing):
 | -P, --password <password> | Livebox password **(required)**                 | None          |
 | -p, --port <port>         | Exporter port                                 | 9100          |
 | -l, --listen <address>    | Listen address                                | 0.0.0.0       |
+| -G, --gateway <address>   | Livebox gateway ip address                    | 192.168.1.1   |
 | -v, --verbose             | Enable verbose logging (repeat for increased verbosity) | Off     |
 | -h, --help                | Display help message                         | N/A           |
 
@@ -97,6 +117,7 @@ Options:
   -l, --listen <address>     listen address [default: 0.0.0.0]
   -v, --verbose...           verbose logging
   -P, --password <password>  Livebox password [required]
+  -G, --gateway <gateway>    Livebox gateway ip address [default: 192.168.1.1]
   -h, --help                 Print help
   -V, --version              Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,7 +383,7 @@ mod tests {
             "-P",
             "mypassword",
             "-G",
-            "192.168.1.10"
+            "192.168.1.10",
         ];
         let matches = parse_args(args);
         assert_eq!(


### PR DESCRIPTION
# Description

<!-- 
    Include a summary of the change and which issue is fixed. Also include relevant motivation and context.
-->

Purpose of this PR is to add an optional arg to the cli, the gateway ip address of the livebox to be used. In case some users have a custom gateway (different than 192.168.1.1 default value), then an optional custom one can be supplied as args.

Fixing and aligning semver as well

Fix: #4 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test update
- [ ] Dependencies update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
